### PR TITLE
MC-11028: Correct support for options in the Download

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-core</artifactId>
-	<version>co-3.1.2-SNAPSHOT</version>
+	<version>co-3.1.2</version>
 	<name>OpenStack4j Core</name>
 	<description>OpenStack Java API</description>
 	<url>http://github.com/ContainX/openstack4j/</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openstack4j-core</artifactId>
-	<version>co-3.1.1</version>
+	<version>co-3.1.2-SNAPSHOT</version>
 	<name>OpenStack4j Core</name>
 	<description>OpenStack Java API</description>
 	<url>http://github.com/ContainX/openstack4j/</url>

--- a/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
+++ b/core/src/main/java/org/openstack4j/api/storage/ObjectStorageObjectService.java
@@ -4,14 +4,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.common.DLPayload;
 import org.openstack4j.model.common.Payload;
-import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.storage.block.options.DownloadOptions;
 import org.openstack4j.model.storage.object.SwiftObject;
+import org.openstack4j.model.storage.object.options.ObjectDeleteOptions;
 import org.openstack4j.model.storage.object.options.ObjectListOptions;
 import org.openstack4j.model.storage.object.options.ObjectLocation;
-import org.openstack4j.model.storage.object.options.ObjectDeleteOptions;
 import org.openstack4j.model.storage.object.options.ObjectPutOptions;
 
 /**
@@ -38,30 +38,30 @@ public interface ObjectStorageObjectService extends RestService {
      * @return List of File objects including Directories
      */
     List<? extends SwiftObject> list(String containerName, ObjectListOptions options);
-    
+
     /**
      * Gets the specified object based on the ObjectLocation {@code location}
-     * 
+     *
      * @param location the object location
      * @return SwiftObject or null if not found
      */
     SwiftObject get(ObjectLocation location);
-    
+
     /**
      * Gets the specified object based on the {@code containerName} and {@code name} of the object
-     * 
+     *
      * @param containerName the objects container name
-     * @param name the name of the object
+     * @param name          the name of the object
      * @return SwiftObject or null if not found
      */
     SwiftObject get(String containerName, String name);
-    
+
     /**
      * Adds/Updates a file to the specified container
-     * 
+     *
      * @param containerName the container name
-     * @param name the name of the file
-     * @param payload the file payload
+     * @param name          the name of the file
+     * @param payload       the file payload
      * @return the ETAG checksum
      */
     String put(String containerName, String name, Payload<?> payload);

--- a/core/src/main/java/org/openstack4j/model/storage/block/options/DownloadOptions.java
+++ b/core/src/main/java/org/openstack4j/model/storage/block/options/DownloadOptions.java
@@ -1,6 +1,7 @@
 package org.openstack4j.model.storage.block.options;
 
 import java.util.List;
+import java.util.Map;
 
 import org.openstack4j.model.common.functions.RangesToHeaderNameValue;
 import org.openstack4j.model.common.header.HeaderNameValue;
@@ -8,34 +9,37 @@ import org.openstack4j.model.common.header.IfCondition;
 import org.openstack4j.model.common.header.Range;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 /**
  * Download options used to determine how the data is returned or if it is returned depending on various conditional
  * options
- * 
+ *
  * @author Jeremy Unruh
  */
 public class DownloadOptions {
 
     List<HeaderNameValue> headers = Lists.newArrayList();
-    
-    private DownloadOptions() { 
+    Map<String, String> queryParams = Maps.newHashMap();
+
+    private DownloadOptions() {
     }
-    
+
     public static DownloadOptions create() {
         return new DownloadOptions();
     }
-    
+
     /**
      * Download select ranges of bytes 
-     * 
+     *
      * @param ranges one or more Range objects
      * @return DownloadOptions for method chaining
      */
     public DownloadOptions range(Range... ranges) {
         HeaderNameValue h = RangesToHeaderNameValue.INSTANCE.apply(ranges);
-        if (h != null)
+        if (h != null) {
             headers.add(h);
+        }
         return this;
     }
     
@@ -63,16 +67,30 @@ public class DownloadOptions {
      */
     public DownloadOptions conditions(IfCondition... condition) {
         if (condition != null) {
-            for (IfCondition c : condition)
+            for (IfCondition c : condition) {
                 headers.add(c.toHeader());
+            }
         }
         return this;
     }
-    
+
     /**
      * @return all headers configured from this options object
      */
     public List<HeaderNameValue> getHeaders() {
         return headers;
     }
+
+    public DownloadOptions queryParam(String key, String value) {
+        if (value == null) {
+            return this;
+        }
+        queryParams.put(key, value);
+        return this;
+    }
+
+    public Map<String, String> getQueryParams() {
+        return queryParams;
+    }
+
 }

--- a/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
+++ b/core/src/main/java/org/openstack4j/openstack/internal/BaseOpenStackService.java
@@ -4,6 +4,7 @@ import static org.openstack4j.core.transport.ClientConstants.HEADER_USER_AGENT;
 import static org.openstack4j.core.transport.ClientConstants.USER_AGENT;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,11 +35,11 @@ public class BaseOpenStackService {
 
     ServiceType serviceType = ServiceType.IDENTITY;
     Function<String, String> endpointFunc;
-    
-    private static ThreadLocal<String> reqIdContainer = new ThreadLocal<String>();
-    
+
+    private static ThreadLocal<String> reqIdContainer = new ThreadLocal<>();
+
     public String getXOpenstackRequestId() {
-    	return reqIdContainer.get();
+        return reqIdContainer.get();
     }
 
     protected BaseOpenStackService() {
@@ -94,8 +95,9 @@ public class BaseOpenStackService {
     }
 
     protected String uri(String path, Object... params) {
-        if (params.length == 0)
+        if (params.length == 0) {
             return path;
+        }
         return String.format(path, params);
     }
 
@@ -113,10 +115,10 @@ public class BaseOpenStackService {
         RequestBuilder<R> req = HttpRequest.builder(returnType).endpointTokenProvider(ses).config(ses.getConfig())
                 .method(method).path(path);
         Map headers = ses.getHeaders();
-        if (headers != null && headers.size() > 0){
-            return new Invocation<R>(req, serviceType, endpointFunc).headers(headers);
-        }else{ 
-            return new Invocation<R>(req, serviceType, endpointFunc);
+        if (headers != null && headers.size() > 0) {
+            return new Invocation<>(req, serviceType, endpointFunc).headers(headers);
+        } else {
+            return new Invocation<>(req, serviceType, endpointFunc);
         }
     }
 
@@ -145,23 +147,34 @@ public class BaseOpenStackService {
 
         public Invocation<R> params(Map<String, ? extends Object> params) {
             if (params != null) {
-                for (String name : params.keySet())
-                    req.queryParam(name, params.get(name));
+                for (String name : params.keySet()) {
+                    Object obj = params.get(name);
+                    if (Collection.class.isAssignableFrom(obj.getClass())) {
+                        for (String value : (Collection<String>) obj) {
+                            req.queryParam(name, value);
+                        }
+                    } else {
+                        req.queryParam(name, obj);
+                    }
+                }
             }
             return this;
         }
 
         public Invocation<R> param(boolean condition, String name, Object value) {
-            if (condition)
+            if (condition) {
                 req.queryParam(name, value);
+            }
             return this;
         }
 
         public Invocation<R> paramLists(Map<String, ? extends Iterable<? extends Object>> params) {
             if (params != null) {
-                for (Map.Entry<String, ? extends Iterable<? extends Object>> pair : params.entrySet())
-                    for (Object value : pair.getValue())
+                for (Map.Entry<String, ? extends Iterable<? extends Object>> pair : params.entrySet()) {
+                    for (Object value : pair.getValue()) {
                         req.queryParam(pair.getKey(), value);
+                    }
+                }
             }
             return this;
         }
@@ -193,8 +206,9 @@ public class BaseOpenStackService {
         }
 
         public Invocation<R> headers(Map<String, ? extends Object> headers) {
-            if (headers != null)
+            if (headers != null) {
                 req.headers(headers);
+            }
             return this;
         }
 
@@ -269,8 +283,9 @@ public class BaseOpenStackService {
     }
 
     protected <T> List<T> toList(T[] arr) {
-        if (arr == null)
+        if (arr == null) {
             return Collections.emptyList();
+        }
         return Arrays.asList(arr);
     }
 

--- a/core/src/main/java/org/openstack4j/openstack/murano/v1/domain/MuranoEnvironment.java
+++ b/core/src/main/java/org/openstack4j/openstack/murano/v1/domain/MuranoEnvironment.java
@@ -1,14 +1,13 @@
 package org.openstack4j.openstack.murano.v1.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
+import java.util.List;
+
 import org.openstack4j.model.murano.v1.builder.EnvironmentBuilder;
-import org.openstack4j.model.murano.v1.domain.Application;
 import org.openstack4j.model.murano.v1.domain.Environment;
 import org.openstack4j.openstack.common.ListResult;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 
 
 public class MuranoEnvironment implements Environment {


### PR DESCRIPTION
Fixed compilation error with JDK11

### Fixes [MC-11028](https://cloud-ops.atlassian.net/browse/MC-11028)

#### Code walkthrough : @GuillaumeVialle 
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
The issue was with large SLO files, it was failing in the rename since we simulated a file upload. It was also taking too much time.

#### Solution
We updated the api to be able to download the manifest SLO content to be able to copy each segments and then create a new manifest file.
Fixed issues with the rollback of segments as well.

#### Test cases
- Manual UI test with Swift to troubleshoot and resolve the situation

#### UI changes
No changes

#### Related PRs
- PR # https://github.com/cloudops/cloudmc-swift-plugin/pull/58
- PR # https://github.com/cloudops/openstack4j/pull/2